### PR TITLE
Add type hints to manage.py.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 
-def main():
+def main() -> None:
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "reko.settings.dev")
     try:


### PR DESCRIPTION
I do not know why but mypy showed errors for this file in vs code. This was an easy fix to avoid it.