### PR TITLE
Remove payment constants.

### DIFF
--- a/reko/reko/constants.py
+++ b/reko/reko/constants.py
@@ -1,6 +1,0 @@
-PAYMENT_OPTIONS = [
-    ("swish_prepay", "Swish i förskott"),
-    ("swish_location", "Swish på plats"),
-    ("card", "Kortbetalning"),
-    ("cash", "Kontant"),
-]


### PR DESCRIPTION
We will just have prepay swish for now. More extensive payment options will be available in the future.